### PR TITLE
Prevent copy to fail when broken symlink

### DIFF
--- a/roles/controller/files/usr/local/bin/kvmjob.sh
+++ b/roles/controller/files/usr/local/bin/kvmjob.sh
@@ -257,7 +257,7 @@ fi
 cat ${sourcesDir}/.ci.yml | yq .script | jq -r .[] > ${sourcesDir}/.ci.sh
 
 ### Copy source git repository into sandbox
-scp -r ${sourcesDir} ${vmUser}@${vmIP}:
+rsync -ae ssh ${sourcesDir} ${vmUser}@${vmIP}:
 
 ### Install additionnal tools into sandbox
 


### PR DESCRIPTION
If a broken symlink is present into the git source tree, scp will merely fail. Using rsync allows to copy symlinks without dereference.